### PR TITLE
Bill PR

### DIFF
--- a/contracts/Baal.sol
+++ b/contracts/Baal.sol
@@ -1,359 +1,272 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.0;
+/// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.4;
 
-interface IERC20 {
-    function transfer(address to, uint256 value) external returns (bool);
-
-    function approve(address spender, uint256 value) external returns (bool);
-
-    function transferFrom(address from, address to, uint256 value) external returns (bool);
-
-    function totalSupply() external view returns (uint256);
-
-    function balanceOf(address who) external view returns (uint256);
-
-    function allowance(address owner, address spender) external view returns (uint256);
-
-    event Transfer(address indexed from, address indexed to, uint256 value);
-
-    event Approval(address indexed owner, address indexed spender, uint256 value);
+/// @notice Interface for Baal banking and extensions.
+interface IBaalBank {
+    function balanceOf(address account) external view returns (uint256); // erc20 helper for balance checks
+    function memberBurn(address member, uint256 votes) external; // amount-weighted vote burn - e.g., member 'ragequit' to claim fair share of capital 
+    function memberMint(address member) external payable returns (uint256); // payable-weighted vote mint - e.g., member submits ETH 'tribute' for votes
 }
 
-
-interface MemberAction {
-    function memberBurn(address member, uint256 votes) external; // vote-weighted member burn - e.g., "ragequit" to claim capital
-    function memberMint(address member, uint256 amount) external; // amount-weighted member vote mint - e.g., submit direct "tribute" for votes
-}
-
-contract ReentrancyGuard { // call wrapper for reentrancy check - see https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/ReentrancyGuard.sol
-    uint256 private constant _NOT_ENTERED = 1;
-    uint256 private constant _ENTERED = 2;
-    uint256 private _status;
-
-    constructor() {
-        _status = _NOT_ENTERED;
-    }
-
-    modifier nonReentrant() {
-        require(_status != _ENTERED, "reentrant");
-        _status = _ENTERED;
-        _;
-        _status = _NOT_ENTERED;
-    }
-}
-
-contract Baal is ReentrancyGuard {
-    address[] public memberList; // array of member accounts summoned or added by proposal
-    address[] public contactList; // array of contacts
-    address[] public ragequitTokens; // array of whitelisted tokens that can be ragequit  
-    uint256 public proposalCount; // counter for proposals submitted 
-    uint256 public totalSupply; // counter for member votes minted - erc20 compatible
-    uint256 public minVotingPeriod; // min period proposal voting in epoch time
-    uint256 public maxVotingPeriod; // max period for proposal voting in epoch time
-    uint8 constant public decimals = 18; // decimals for erc20 vote accounting - 18 is default for ETH
-    string public name; // name for erc20 vote accounting
-    string public symbol; // symbol for erc20 vote accounting
+/// @notice Baal for Guilds.
+contract Baal {
+    address[] guildTokens; // internal accounting for erc20 tokens approved for `ragequit()` and `members` 'removal'
+    address[] memberList; // internal array of `members` accounts summoned or added by proposal
+    uint public proposalCount; // counter for proposals submitted
+    uint public totalSupply; // counter for `members` votes minted with erc20 accounting
+    uint public minVotingPeriod; // min. period proposal voting in epoch time
+    uint public maxVotingPeriod; // max. period for proposal voting in epoch time
+    uint8 constant public decimals = 18; // decimals for erc20 vote accounting - 18 is default to match ETH and most erc20
+    string public name; // 'name' for erc20 vote accounting
+    string public symbol; // 'symbol' for erc20 vote accounting
+    bytes4 constant SIG_TRANSFER = 0xa9059cbb; // transfer(address,uint256)
+    bytes4 constant SIG_TRANSFER_FROM = 0x23b872dd; // transferFrom(address,address,uint256)
     
-    mapping(address => uint256) public balanceOf; // mapping member accounts to votes
-    mapping(address => bool) public contractList; // mapping contract approved for member calls 
-    mapping(address => bool) public contacts; // mapping of approved addresses for proposals
-    mapping(address => mapping(uint256 => bool)) public voted; // mapping proposal number to whether member voted 
-    mapping(address => uint256) public highestIndexYesVote; // mapping most recent number where member voted yes 
-    mapping(uint256 => Proposal) public proposals; // mapping proposal number to struct details
+    mapping(address => uint) public balanceOf; // maps `members` accounts to votes with erc20 accounting
+    mapping(address => bool) public banks; // maps contracts approved for `memberAction()` that burn or mint votes
+    mapping(address => Member) public members; // maps `members` accounts to struct details
+    mapping(uint => Proposal) public proposals; // maps proposal number to struct details
     
-    event SubmitProposal(address indexed proposer, address indexed target, uint256 proposal, uint256 value, bytes data, uint256 flag, string details); // emits when member submits proposal 
-    event SubmitVote(address indexed member, uint256 proposal, bool approve); // emits when member submits vote on proposal
-    event ProcessProposal(uint256 proposal); // emits when proposal is processed and finalized
-    event Receive(address indexed sender, uint256 value); // emits when ether (ETH) is received
-    event Transfer(address indexed from, address indexed to, uint256 amount); // emits when member votes are minted or burned
-    event ProcessMemberProposal(address indexed from, address indexed to, uint256 amount, uint256 proposal);
-    event ProcessMemberKick(address indexed from, address indexed to, uint256 amount, uint256 proposal);
     event SummonComplete(address[] indexed summoners, address[] indexed ragequitTokens, uint256[] votes, uint256 minVotingPeriod, uint256 maxVotingPeriod, string name, string symbol);
-    event Ragequit(address quitter, uint256 sharesToBurn);
-    event CancelProposal(uint256 proposalNum, address proposer);
-
+    event SubmitProposal(address[] target, uint8 indexed flag, uint indexed proposal, uint[] value, bytes[] data, string details); // emits when `members` submit proposal 
+    event SubmitVote(address indexed member, uint balance, uint indexed proposal, bool approve); // emits when `members` submit vote on proposal
+    event ProcessProposal(uint indexed proposal); // emits when proposal is processed and executed
+    event Transfer(address indexed from, address indexed to, uint amount); // emits when `members`' votes are minted or burned with erc20 accounting
+    
+    /// @dev Reentrancy guard.
+    uint unlocked = 1;
+    modifier lock() {
+        require(unlocked == 1, 'locked');
+        unlocked = 0;
+        _;
+        unlocked = 1;
+    }
+    
+    struct Member {
+        bool exists; // tracks `members` account registration for `memberAction()` and `submitProposal()`
+        uint highestIndexYesVote; // highest proposal index # on which the member voted YES
+        mapping(uint => mapping(uint => bool)) voted; // maps votes on proposals by `members` account - gets votes cast and whether approved
+    }
     
     struct Proposal {
-        address proposer; // account that submits proposal;
-        address target; // account that receives low-level call `data` and ETH `value` - if `membership` is `true` and data `length` is 0, the account that will receive `value` votes - otherwise, the account that will lose votes
-        uint256 value; // ETH sent from Baal to execute approved proposal low-level call - if `membership` is `true` and data `length` is 0, reflects `votes` to grant member
-        uint256 noVotes; // counter for member no votes to calculate approval on processing
-        uint256 yesVotes; // counter for member yes votes to calculate approval on processing
-        uint256 votingEnds; // termination date for proposal in seconds since epoch - derived from votingPeriod
-        bytes data; // raw data sent to `target` account for low-level call
-        bool[8] flags; // [0 cancelled, 1 processed, 2 didPass, 3 action call, 4 add member, 5 kick member, 6 whitelist contact, 7 whitelist token]
+        address[] target; // account(s) that receives low-level call `data` and ETH `value` - if `membership` flag (2) or `removal` (3), account(s) that will receive or lose `value` votes, respectively
+        uint[] value; // ETH sent from Baal to execute approved proposal low-level call(s)
+        uint yesVotes; // counter for `members` 'yes' votes to calculate approval on processing
+        uint noVotes; // counter for `members` 'no' votes to calculate approval on processing
+        uint votingEnds; // termination date for proposal in seconds since epoch - derived from `votingPeriod`
+        bytes[] data; // raw data sent to `target` account for low-level call
+        bool[6] flags; // flags for proposal type and status - [action, governance, membership, removal, passed, processed] 
         string details; // context for proposal - could be IPFS hash, plaintext, or JSON
     }
     
-    /// @dev deploy Baal and create initial array of member accounts with specific vote weights
-    /// @param summoners Accounts to add as members
-    /// @param votes Voting weight per member
-    /// @param _minVotingPeriod Min Voting period in seconds for members to cast votes on proposals
-    /// @param _minVotingPeriod Max Voting period in seconds for members to cast votes on proposals
-    /// @param _name Name for erc20 vote accounting
-    /// @param _symbol Symbol for erc20 vote accounting
-    constructor(address[] memory summoners, address[] memory tokens, uint256[] memory votes, uint256 _minVotingPeriod, uint256 _maxVotingPeriod, string memory _name, string memory _symbol) {
-        for (uint256 i = 0; i < summoners.length; i++) {
-             totalSupply += votes[i]; // total votes incremented by summoning
-             minVotingPeriod = _minVotingPeriod; 
-             maxVotingPeriod = _maxVotingPeriod; 
-             name = _name;
-             symbol = _symbol;
-             balanceOf[summoners[i]] = votes[i]; // vote weights granted to member
-             memberList.push(summoners[i]); // update list of member accounts
+    /// @notice Deploy Baal and create initial array of `members` accounts with specific voting weights.
+    /// @param _guildTokens Tokens approved for internal accounting - `ragequit()` of votes.
+    /// @param _banks External contracts approved for `memberAction()`.
+    /// @param summoners Accounts to add as `members`.
+    /// @param votes Voting weight among `members`.
+    /// @param _minVotingPeriod Min. voting period in seconds for `members` to cast votes on proposals.
+    /// @param _maxVotingPeriod Max. voting period in seconds for `members` to cast votes on proposals.
+    /// @param _name Name for erc20 vote accounting.
+    /// @param _symbol Symbol for erc20 vote accounting.
+    constructor(address[] memory _guildTokens, address[] memory _banks, address[] memory summoners, uint[] memory votes, uint _minVotingPeriod,  uint _maxVotingPeriod, string memory _name, string memory _symbol) {
+        for (uint i = 0; i < summoners.length; i++) {
+             guildTokens.push(_guildTokens[i]); // update array of `guildTokens` for `ragequit()`
+             memberList.push(summoners[i]); // update array of `members`
+             totalSupply += votes[i]; // total votes incremented by summoning with erc20 accounting
+             balanceOf[summoners[i]] = votes[i]; // vote weights granted to summoning `members` with erc20 accounting
+             banks[_banks[i]] = true; // update mapping of approved `banks`
+             members[summoners[i]].exists = true; // record that summoning `members` `exists`
+             emit Transfer(address(this), summoners[i], votes[i]); // event reflects mint of erc20 votes to summoning `members`
         }
-        
-        for (uint256 i = 0; i < tokens.length; i++){
-            ragequitTokens.push(tokens[i]);
-        }
-        
-        emit SummonComplete(summoners, tokens, votes, _minVotingPeriod, _maxVotingPeriod, _name, _symbol);
+        minVotingPeriod = _minVotingPeriod; 
+        maxVotingPeriod = _maxVotingPeriod; 
+        name = _name; // Baal 'name' with erc20 accounting
+        symbol = _symbol; // Baal 'symbol' with erc20 accounting
+        proposals[0].flags[5] = true; // internal trick to save gas in validating proposals
+        emit SummonComplete(summoners, _guildTokens, votes, _minVotingPeriod, _maxVotingPeriod, _name, _symbol);
     }
     
-    /// @dev Submit proposal for member approval within voting period
-    /// @param target Account that receives low-level call `data` and ETH `value` - if `membership`, the account that will receive `value` votes - if `removal`, the account that will lose votes
-    /// @param value ETH sent from Baal to execute approved proposal low-level call - if `membership`, reflects `votes` to grant member
-    /// @param data Raw data sent to `target` account for low-level call 
-    /// @param flag notes proposal type
-    /// @param details Context for proposal - could be IPFS hash, plaintext, or JSON
-    function submitProposal(address target, uint256 value, uint256 votingLength, bytes calldata data, uint256 flag, string calldata details) external nonReentrant returns (uint256 count) {
-        require(balanceOf[msg.sender] > 0 || contacts[msg.sender] == true, "Baal:: Must be a member or contact");
-        require(votingLength >= minVotingPeriod && votingLength <= maxVotingPeriod, "Baal:: Voting period too long or short");
-        require(flag != 0 && flag != 1 && flag != 2, "Baal:: invalid flag");
-        
-        proposalCount++;
-        uint256 proposal = proposalCount;
-        bool[8] memory flags; 
-        flags[flag] = true;
-        
-        proposals[proposal] = Proposal(msg.sender, target, value, 0, 0, block.timestamp + votingLength, data, flags, details); // push params into proposal struct - start timer
-        
-        emit SubmitProposal(msg.sender, target, proposal, value, data, flag, details);
-        return proposal;
+    /// @notice Execute `members`' action to mint or burn votes against external contract.
+    /// @param bank Account to call to trigger `members`' action - must be approved in `banks`.
+    /// @param amount Number of `members`' votes to submit in action.
+    /// @param mint Confirm whether transaction involves mint - if `false,` perform balance-based burn.
+    function memberAction(IBaalBank bank, uint amount, bool mint) external lock payable {
+        require(banks[address(bank)], '!bank'); // check bank is approved
+        require(members[msg.sender].exists, '!member'); // check membership
+        if (mint) {
+            uint256 minted = bank.memberMint{value: msg.value}(msg.sender); // mint from `bank` `msg.value` return based on member
+            totalSupply += minted; // add to total `members`' votes with erc20 accounting
+            balanceOf[msg.sender] += minted; // add votes to member account with erc20 accounting
+            emit Transfer(address(this), msg.sender, minted); // event reflects mint of votes with erc20 accounting
+        } else {    
+            totalSupply -= amount; // subtract from total `members`' votes with erc20 accounting
+            balanceOf[msg.sender] -= amount; // subtract votes from member account with erc20 accounting
+            bank.memberBurn(msg.sender, amount); // burn `amount` againt `target` based on member
+            emit Transfer(address(this), address(0), amount); // event reflects burn of votes with erc20 accounting
+        }
     }
     
-    /// @dev Submit vote - caller must have uncast votes - proposal must exist, be unprocessed, and voting period cannot be finished
-    /// @param proposal Number of proposal in `proposals` mapping to cast vote on 
-    /// @param approve If `true`, member will cast `yesVotes` onto proposal - if `false, `noVotes` will be cast
-    function submitVote(uint256 proposal, bool approve) external nonReentrant returns (uint256 count) {
+    /*****************
+    PROPOSAL FUNCTIONS
+    *****************/
+    /// @notice Submit proposal to Baal `members` for approval within voting period - proposer must be registered member.
+    /// @param target Account that receives low-level call `data` and ETH `value` - if `membership` flag (2), the account that will receive `value` votes - if `removal` (3), the account that will lose `value` votes.
+    /// @param value ETH sent from Baal to execute approved proposal low-level call.
+    /// @param data Raw data sent to `target` account for low-level call.
+    /// @param details Context for proposal - could be IPFS hash, plaintext, or JSON.
+    function submitProposal(address[] calldata target, uint8 flag, uint votingLength, uint[] calldata value, bytes[] calldata data, string calldata details) external lock returns (uint proposal) {
+        require(votingLength >= minVotingPeriod && votingLength <= maxVotingPeriod, 'Baal:: Voting period too long or short');
+        require(flag <= 5, '!flag'); // check flag is not out of bounds
+        proposalCount++; // increment proposals
+        proposal = proposalCount; // set proposal number from count
+        bool[6] memory flags; // stage flags - [governance, membership, removal, passed, processed]
+        flags[flag] = true; // flag proposal type 
+        proposals[proposal] = Proposal(target, value, 0, 0, block.timestamp + votingLength, data, flags, details); // push params into proposal struct - start vote timer
+        emit SubmitProposal(target, flag, proposal, value, data, details);
+    }
+    
+    /// @notice Submit vote - proposal must exist and voting period must not have ended - non-member can cast `0` vote to signal.
+    /// @param proposal Number of proposal in `proposals` mapping to cast vote on.
+    /// @param approve If `true`, member will cast `yesVotes` onto proposal - if `false, `noVotes` will be counted.
+    function submitVote(uint proposal, bool approve) external lock {
         Proposal storage prop = proposals[proposal];
-        
-        require(proposal <= proposalCount, "Baal::!exist");
-        require(prop.votingEnds >= block.timestamp, "Baal:: voting finished");
-        require(!prop.flags[0] && !prop.flags[1], "Baal:: processed or cancelled");
-        require(balanceOf[msg.sender] > 0, "Baal:: !votes");
-        require(!voted[msg.sender][proposal], "Baal:: voted");
-        
-        if (approve) {prop.yesVotes += balanceOf[msg.sender];} // cast yes votes
-        else {prop.noVotes += balanceOf[msg.sender];} // cast no votes
-        voted[msg.sender][proposal] = true; // reflect member voted
-        highestIndexYesVote[msg.sender] = proposal;
-        
-        emit SubmitVote(msg.sender, proposal, approve);
-        return proposal;
+        uint balance = balanceOf[msg.sender]; // gas-optimize variable
+        require(prop.votingEnds >= block.timestamp, 'ended'); // check voting period has not ended
+        if (approve) {prop.yesVotes += balance;} // cast 'yes' votes per member balance to proposal
+        else {prop.noVotes += balance;} // cast 'no' votes per member balance to proposal
+        members[msg.sender].voted[proposal][balance] = approve; // record vote to member struct per account
+        emit SubmitVote(msg.sender, balance, proposal, approve);
     }
     
-    /// @dev Process proposal and execute low-level call or membership management - proposal must exist, be unprocessed, and voting period must be finished
-    /// @param proposal Number of proposal in `proposals` mapping to process for execution
-    function processProposal(uint256 proposal) external nonReentrant returns (bool success, bytes memory retData) {
+    // ********************
+    // PROCESSING FUNCTIONS
+    // ********************
+    /// @notice Process 'action' proposal (0) and execute low-level call(s) - proposal must be counted, unprocessed, and in voting period.
+    /// @param proposal Number of proposal in `proposals` mapping to process for execution.
+    function processActionProposal(uint proposal) external lock returns (bool[] memory successes, bytes[] memory results) {
+        processingReady(proposal); // validate basic processing requirements
         Proposal storage prop = proposals[proposal];
-
-        require(processingReady(proposal), "Baal:: !ready for processing");
-        require(!prop.flags[0] && !prop.flags[1], "Baal:: cancelled or processed");
-      
-        bool _didPass = didPass(proposal);
-        if (_didPass){
-            (bool callSuccess, bytes memory returnData) = proposals[proposal].target.call{value: proposals[proposal].value}(proposals[proposal].data); // execute low-level call
-            require(callSuccess, "Baal:: action failed");
-            return (callSuccess, returnData); // return call success and data
-        }
-        
-        prop.flags[1] = true; // reflect proposal processed
+        require(prop.flags[0], '!action'); // check proposal type and whether already processed
+        if (didPass(proposal)) { // check if proposal approved by simple majority of `members`
+            for (uint i = 0; i < prop.target.length; i++) {
+                (bool success, bytes memory result) = prop.target[i].call{value:prop.value[i]}(prop.data[i]); // execute low-level call
+                successes[i] = success;
+                results[i] = result;}}
+         prop.flags[5] = true; // flag that proposal processed
+         emit ProcessProposal(proposal);
+    }
+    
+    /// @notice Process 'governance' proposal (1) - proposal must be counted, unprocessed, and in voting period.
+    /// @param proposal Number of proposal in `proposals` mapping to process for execution.
+    function processGovernanceProposal(uint proposal) external lock {
+        processingReady(proposal); // validate basic processing requirements
+        Proposal storage prop = proposals[proposal];
+        require(prop.flags[1], '!governance'); // check proposal type and whether already processed
+        if (didPass(proposal)) { // check if proposal approved by simple majority of members
+            for (uint i = 0; i < prop.target.length; i++) {
+                if (prop.value[i] > 0) { // crib `value` to toggle between approving or removing bank
+                    banks[prop.target[i]] = true; // approve bank
+                } else {
+                    banks[prop.target[i]] = false;}} // remove bank
+                if (prop.value[0] > 0) {maxVotingPeriod = prop.value[0];}} // reset voting period to first `value`
+        prop.flags[5] = true; // flag that proposal processed
         emit ProcessProposal(proposal);
     }
     
-    
-    /// @dev Process proposal for membership management - proposal must exist, be unprocessed, and voting period must be finished
-    /// @param proposal Number of proposal in `proposals` mapping to process for execution
-    function processMemberProposal(uint256 proposal) external nonReentrant returns (uint256 shares) {
+    /// @notice Process 'membership' proposal (2) - proposal must be counted, unprocessed, and in voting period.
+    /// @param proposal Number of proposal in `proposals` mapping to process for execution.
+    function processMemberProposal(uint proposal) external lock {
+        processingReady(proposal); // validate basic processing requirements
         Proposal storage prop = proposals[proposal];
-        require(processingReady(proposal), "Baal:: !ready for processing");
-        require(prop.flags[4], "Baal:: !membership proposal");
-        
-        bool _didPass = didPass(proposal);
-        if (_didPass) { // check if proposal approved by members
-            address target = proposals[proposal].target;
-            uint256 value = proposals[proposal].value;
-                
-            if(balanceOf[target] == 0) {memberList.push(target);} // update list of member accounts if new
-                
-            totalSupply += value; // add to total member votes
-            balanceOf[target] += value; // add to member votes
-            
-            return(value);
-        }
-        
-        prop.flags[1] = true; // reflect proposal processed
-        emit ProcessMemberProposal(address(this), proposals[proposal].target, proposals[proposal].value, proposal); // event reflects mint of erc20 votes
+        require(prop.flags[2], '!member'); // check proposal type and whether already processed
+        if (didPass(proposal)) { // check if proposal approved by simple majority of members
+            for (uint i = 0; i < prop.target.length; i++) {
+                if (!members[prop.target[i]].exists) {memberList.push(prop.target[i]);} // update list of member accounts if new
+                    totalSupply += prop.value[i]; // add to total member votes
+                    balanceOf[prop.target[i]] += prop.value[i]; // add to `target` member votes
+                    emit Transfer(address(this), prop.target[i], prop.value[i]);}} // event reflects mint of erc20 votes
+        prop.flags[5] = true; // flag that proposal processed
+        emit ProcessProposal(proposal);
     }
     
-    function processMemberKick(uint256 proposal) external nonReentrant returns (bool success) {
+    /// @notice Process 'removal' proposal (3) - proposal must be counted, unprocessed, and in voting period.
+    /// @param proposal Number of proposal in `proposals` mapping to process for execution.
+    function processRemovalProposal(uint proposal) external lock {
+        processingReady(proposal); // validate basic processing requirements
         Proposal storage prop = proposals[proposal];
-        
-        require(processingReady(proposal), "Baal:: !ready for processing");
-        require(prop.flags[5], "Baal:: !membership kick proposal");
-
-        bool _didPass = didPass(proposal);
-
-        if (_didPass) {
-            address target = proposals[proposal].target;
-            uint256 balance = balanceOf[target];
-                
-            _ragequit(target, balance);
-                
-            return(true);
-        }
-        
-        prop.flags[1] = true; // reflect proposal processed
-        emit ProcessMemberKick(address(this), proposals[proposal].target, proposals[proposal].value, proposal); // event reflects mint of erc20 votes
+        require(prop.flags[3], '!removal'); // check proposal type and whether already processed
+        if (didPass(proposal)) { // check if proposal approved by simple majority of members
+            for (uint i = 0; i < prop.target.length; i++) {
+                totalSupply -= prop.value[i]; // subtract `balance` from total member votes
+                balanceOf[prop.target[i]] -= prop.value[i]; // subtract member votes
+                emit Transfer(address(this), address(0), prop.value[i]);}} // event reflects burn of erc20 votes
+        prop.flags[5] = true; // flag that proposal processed
+        emit ProcessProposal(proposal);
     }
     
-    function processWhitelist(uint256 proposal) external nonReentrant returns (bool success) {
-        Proposal storage prop = proposals[proposal];
-        
-        require(processingReady(proposal), "Baal:: !ready for processing");
-        require(prop.flags[6] || prop.flags[7], "Baal:: !contact");
-
-        bool _didPass = didPass(proposal);
-
-        if (_didPass) {
-            
-            if (prop.flags[6]){
-            address target = prop.target;
-            contacts[target] = true;
-            contactList.push(target);
-            } 
-            
-            if(prop.flags[7]){
-            address target = prop.target;
-            ragequitTokens.push(target);
-            }
-            
-            return(true);
-        }
-        
-        prop.flags[1] = true; // reflect proposal processed
-        emit ProcessMemberKick(address(this), proposals[proposal].target, proposals[proposal].value, proposal); // event reflects mint of erc20 votes
-    }
-    
-    function ragequit(uint256 sharesToBurn) external nonReentrant {
-        require(balanceOf[msg.sender] > 0, "Baal:: no shares to burn");
-        _ragequit(msg.sender, sharesToBurn);
-    }
-    
-    function _ragequit(address memberAddress, uint256 sharesToBurn) internal {
-        require(balanceOf[memberAddress] >= sharesToBurn, "Baal::insufficient shares");
-        require(proposals[highestIndexYesVote[memberAddress]].flags[1], "Baal::cannot ragequit until highest index proposal member voted YES on is processed");
+    function ragequit(address memberAddress, uint256 sharesToBurn) external {
+        require(balanceOf[memberAddress] >= sharesToBurn, 'insufficient shares');
+        //require(members[memberAddress].highestIndexYesVote, 'ragequit until highest index proposal member voted YES on is processed');
         uint256 initialTS = totalSupply;
         totalSupply -= sharesToBurn; // add to total member votes
         balanceOf[memberAddress] -= sharesToBurn; // add to member votes
-
-        for (uint256 i = 0; i < ragequitTokens.length; i++) {
-            uint256 amountToRagequit = fairShare(IERC20(ragequitTokens[i]).balanceOf(address(this)), sharesToBurn, initialTS);
-            if (amountToRagequit > 0) { // gas optimization to allow a higher maximum token limit
-                // deliberately not using safemath here to keep overflows from preventing the function execution (which would break ragekicks)
-                // if a token overflows, it is because the supply was artificially inflated to oblivion, so we probably don't care about it anyways
-                IERC20(ragequitTokens[i]).transfer(memberAddress, amountToRagequit);
-            }
-        }
-
-        emit Ragequit(msg.sender, sharesToBurn);
     }
     
-    /// @dev Execute member action against external contract - caller must have votes
-    /// @param target Account to call to trigger component transaction
-    /// @param amount Number of member votes to involve in transaction
-    /// @param mint Confirm whether transaction involves mint - if `false,` then perform balance-based burn
-    function memberAction(address target, uint256 amount, bool mint) external nonReentrant {
-        require(balanceOf[msg.sender] > 0, "Baal:: !active");
-        require(contractList[target], "Baal:: !listed");  
-        if (mint) {
-            MemberAction(target).memberMint(msg.sender, amount);
-            totalSupply += amount; // add to total member votes
-            balanceOf[msg.sender] += amount; // add to member votes
-            emit Transfer(address(this), msg.sender, amount); // event reflects mint of erc20 votes
-        } else {    
-            MemberAction(target).memberBurn(msg.sender, amount);
-            totalSupply -= amount; // subtract from total member votes
-            balanceOf[msg.sender] -= amount; // subtract member votes
-            emit Transfer(address(this), address(0), amount); // event reflects burn of erc20 votes
-        }
+    /***************
+    GETTER FUNCTIONS
+    ***************/
+    /// @notice Returns array list of approved guild tokens in Baal for member exits.
+    function getGuildTokens() external view returns (address[] memory tokens) {
+        tokens = guildTokens;
+    }
+
+    /// @notice Returns array list of member accounts in Baal.
+    function getMemberList() external view returns (address[] memory membership) {
+        membership = memberList;
+    }
+
+    /// @notice Returns flags for proposal type and status in Baal.
+    function getProposalFlags(uint proposal) external view returns (bool[6] memory flags) {
+        flags = proposals[proposal].flags;
     }
     
-     /// @dev Checks if proposal passed
-    function didPass(uint256 proposal) internal returns (bool) {
+    /***************
+    HELPER FUNCTIONS
+    ***************/
+    /// @notice Deposit ETH.
+    receive() external payable {}
+    
+    /// @notice Checks if proposal passed.
+    function didPass(uint256 proposal) internal returns (bool passed) {
         Proposal storage prop = proposals[proposal];
-        require(prop.yesVotes > prop.noVotes, "Baal::proposal failed");
-        prop.flags[3] = true;
-        return true;
+        passed = prop.yesVotes > prop.noVotes;
+        prop.flags[4] = true; // flag that vote passed
     }
     
-    /// @dev Checks if proposal is ready to be processed (allows for possible early execution)
-    function processingReady(uint256 proposal) internal view returns (bool) {
-        require(proposal <= proposalCount, "Baal::!exist");
-        require(!proposals[proposal].flags[1], "Baal:: already processed");
-        require(proposalCount == 1 || proposals[proposalCount-1].flags[1], "previous proposal must be processed");
-        
-        uint256 halfShares = totalSupply / 2;
-        
-        if(proposals[proposal].votingEnds >= block.timestamp){ // voting period done
+    /// @dev Internal calculation for member fair share of `guildTokens`.
+    function fairShare(uint256 balance, uint256 shares, uint256 total) private pure returns (uint256 amount) {
+        require(total != 0);
+        if (balance == 0) {amount = 0;}
+        uint prod = balance * shares;
+        if (prod / balance == shares) { // no overflow in multiplication above?
+            amount = prod / total;
+        }
+        amount = (balance / total) * shares;
+    }
+    
+    /// @dev Internal checks to validate basic proposal processing requirements. 
+    function processingReady(uint proposal) private view returns (bool) {
+        require(proposal <= proposalCount, '!exist'); // check proposal exists
+        require(proposals[proposal - 1].flags[5], 'prev!processed'); // check previous proposal has processed
+        require(!proposals[proposal].flags[5], 'processed'); // check given proposal has not yet processed
+        require(proposals[proposal].votingEnds <= block.timestamp, '!ended'); // check voting period has ended
+        uint halfShares = totalSupply / 2;
+        if (proposals[proposal].votingEnds >= block.timestamp) { // voting period done
             return true;
-        } else if(proposals[proposal].yesVotes > halfShares ) { // early execution b/c of 50%+
+        } else if (proposals[proposal].yesVotes > halfShares ) { // early execution b/c of 50%+
             return true;
         } else {
-            return false; //not ready
+            return false; // not ready
         }
     }
-    
-    function cancelProposal(uint256 proposal) external nonReentrant {
-        Proposal storage prop = proposals[proposal];
-        require(!prop.flags[0], "proposal has already been cancelled");
-        require(!prop.flags[1], "proposal has already been processed");
-        require(msg.sender == prop.proposer, "solely the proposer can cancel");
-
-        prop.flags[0] = true; // cancelled
-        
-        emit CancelProposal(proposal, msg.sender);
-    }
-    
-    /// @dev Return array list of member accounts in Baal
-    function getMembers() external view returns (address[] memory membership) {
-        return memberList;
-    }
-    
-        /// @dev Return array list of member accounts in Baal
-    function getContacts() external view returns (address[] memory allContacts) {
-        return contactList;
-    }
-    
-    function getProposalFlags(uint256 proposal) public view returns (bool[8] memory) {
-        return proposals[proposal].flags;
-    }
-    
-    function fairShare(uint256 balance, uint256 shares, uint256 totalSupply) internal pure returns (uint256) {
-        require(totalSupply != 0);
-
-        if (balance == 0) { return 0; }
-
-        uint256 prod = balance * shares;
-
-        if (prod / balance == shares) { // no overflow in multiplication above?
-            return prod / totalSupply;
-        }
-
-        return (balance / totalSupply) * shares;
-    }
-    
-    /// @dev fallback to collect received ether into Baal
-    receive() external payable {emit Receive(msg.sender, msg.value);}
 }


### PR DESCRIPTION
PR includes the following WIP changes: 

- Adds very basic ragequit for whitelisted tokens in the contract
- Uses ragequit for member kicks 
- Splits out proposal processing into different functions based on type of proposal
- Adds early execution as a possibility for proposals 
- Adds ability to cancel proposals that haven't been processed 

Also, stuck with the bool for flags after realizing that this will probably allow for it to be used with existing minions. 

Open Question: 
With the additional of ragequit should we introduce some sort of grace period concept again? I think this might make sense, otherwise RQ only works in the scenario where the quitter votes no on a proposal and thinks it's going to pass. 

NOTE: Haven't tested all of these changes, but want to get them into a PR for conceptual review.