### PR TITLE
Improve test coverage: shamans minting delegated voting shares

### DIFF
--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -345,7 +345,9 @@ describe('Baal contract', function () {
       expect(await baal.getCurrentVotes(summoner.address)).to.equal(shares + minting)
 
       // mint shares for the delegator
-      await baalAsShaman.mintShares([applicant.address], [minting])
+      await expect(
+        baalAsShaman.mintShares([applicant.address], [minting])
+      ).to.emit(baal, 'DelegateVotesChanged').withArgs(summoner.address, shares + 2 * minting)
 
       expect(await baal.balanceOf(applicant.address)).to.equal(2 * minting)
       expect(await baal.delegates(applicant.address)).to.equal(summoner.address)

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -286,6 +286,7 @@ describe('Baal contract', function () {
       await expect(
         baalAsShaman.mintShares([summoner.address], [minting])
       ).to.emit(baal, 'Transfer').withArgs(zeroAddress, summoner.address, minting)
+      .to.emit(baal, 'DelegateVotesChanged').withArgs(summoner.address, shares, shares+minting)
       expect(await baal.balanceOf(summoner.address)).to.equal(shares + minting)
     })
 
@@ -295,6 +296,7 @@ describe('Baal contract', function () {
       await expect(
         baalAsShaman.burnShares([summoner.address], [burning])
       ).to.emit(baal, 'Transfer').withArgs(summoner.address, zeroAddress, burning)
+      .to.emit(baal, 'DelegateVotesChanged').withArgs(summoner.address, shares, shares - burning)
       expect(await baal.balanceOf(summoner.address)).to.equal(shares - burning)
     })
 

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -347,7 +347,7 @@ describe('Baal contract', function () {
       // mint shares for the delegator
       await expect(
         baalAsShaman.mintShares([applicant.address], [minting])
-      ).to.emit(baal, 'DelegateVotesChanged').withArgs(summoner.address, shares + 2 * minting)
+      ).to.emit(baal, 'DelegateVotesChanged').withArgs(summoner.address, shares + minting, shares + 2 * minting)
 
       expect(await baal.balanceOf(applicant.address)).to.equal(2 * minting)
       expect(await baal.delegates(applicant.address)).to.equal(summoner.address)

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -331,7 +331,7 @@ describe('Baal contract', function () {
       expect(await baal.getCurrentVotes(applicant.address)).to.equal(minting)
       expect(await baal.getCurrentVotes(summoner.address)).to.equal(shares)
 
-      // submit proposal for member to delegate shares from applicant to the summoner
+      // delegate shares from applicant to the summoner
       const baalAsApplicant = baal.connect(applicant)
 
       await expect(

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -214,7 +214,7 @@ describe('Baal contract', function () {
     })
   })
 
-  describe.only('shaman actions', function () {
+  describe('shaman actions', function () {
     it ('sad case - shaman is not whitelisted', async function (){
       expect(await baal.shamans(summoner.address)).to.be.false
       


### PR DESCRIPTION
- Extract submitAndProcessProposal as a separate utility function
- Remove describe.only from the shaman actions test cases
- Add expectation of emission of DelegateVotesChanged event in mintShares
- Add test case for shamans minting delegated shares