### PR TITLE
Improve test coverage actions via proposal

### DIFF
--- a/contracts/Baal.sol
+++ b/contracts/Baal.sol
@@ -467,7 +467,7 @@ contract Baal is Executor, Initializable {
         if (prop.yesVotes > prop.noVotes) {
             proposalsPassed[proposal] = true; /*flag that proposal passed - allows minion-like extensions*/
             bool success = processActionProposal(prop); /*execute 'action'*/
-            if (revertOnFailure) require(success, "call failure");
+            if (revertOnFailure) require(success, "call failure in proposed action");
             if (!success) prop.actionFailed = true;
         }
 

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -90,8 +90,8 @@ describe('Baal contract', function () {
     return await baalAsAddress.processProposal(proposalIndex, proposal.revertOnFailure)
   }
 
-  async function enableShaman(shamanToEnable: SignerWithAddress) {
-    const enableShamanAction = await baal.interface.encodeFunctionData('setShamans', [[shamanToEnable.address], true])
+  async function setShamans(shamansToEnable: [SignerWithAddress]) {
+    const enableShamanAction = await baal.interface.encodeFunctionData('setShamans', [shamansToEnable.map(a => a.address), true])
     return await submitAndProcessProposal(baal, enableShamanAction)
   }
 
@@ -236,7 +236,7 @@ describe('Baal contract', function () {
     })
 
     it('sad case - minting and burning array parity', async function () {
-      await enableShaman(applicant)
+      await setShamans([applicant])
       const baalAsApplicant = await baal.connect(applicant)
       
       await expect(
@@ -275,7 +275,7 @@ describe('Baal contract', function () {
     it('happy case - allows a proposal to enable a shaman', async function () {
       expect(await baal.shamans(summoner.address)).to.be.false
 
-      await enableShaman(summoner)
+      await setShamans([summoner])
 
       expect(await baal.shamans(summoner.address)).to.be.true
     })

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -474,7 +474,7 @@ describe('Baal contract', function () {
       
       await expect(
         submitAndProcessProposal(baal, mintSharesAction)
-      ).to.emit(baal, 'ProcessProposal')
+      ).to.emit(baal, 'ProcessProposal').withArgs(1)
 
       expect(await baal.balanceOf(applicant.address)).to.equal(minting)
     })

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -478,6 +478,21 @@ describe('Baal contract', function () {
 
       expect(await baal.balanceOf(applicant.address)).to.equal(minting)
     })
+
+    it('happy case - burn shares', async function () {
+      const burning = 100
+
+      expect(await baal.balanceOf(summoner.address)).to.equal(shares)
+
+      const burnSharesAction = await baal.interface.encodeFunctionData('burnShares', [[summoner.address], [burning]])
+      
+      await expect(
+        submitAndProcessProposal(baal, burnSharesAction)
+      ).to.emit(baal, 'ProcessProposal').withArgs(1)
+
+      expect(await baal.balanceOf(summoner.address)).to.equal(shares - burning)
+
+    })
   })
 
   describe('ragequit', function () {

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -491,6 +491,34 @@ describe('Baal contract', function () {
       ).to.emit(baal, 'ProcessProposal').withArgs(1)
 
       expect(await baal.balanceOf(summoner.address)).to.equal(shares - burning)
+    })
+
+    it('happy case - mint loot', async function () {
+      const minting = 100
+
+      expect(await baal.balanceOf(applicant.address)).to.equal(0)
+
+      const mintSharesAction = await baal.interface.encodeFunctionData('mintLoot', [[applicant.address], [minting]])
+      
+      await expect(
+        submitAndProcessProposal(baal, mintSharesAction)
+      ).to.emit(baal, 'ProcessProposal').withArgs(1)
+
+      expect((await (baal.members(applicant.address))).loot).to.equal(minting)
+    })
+
+    it('happy case - burn loot', async function () {
+      const burning = 100
+
+      expect((await (baal.members(summoner.address))).loot).to.equal(loot)
+
+      const burnLootAction = await baal.interface.encodeFunctionData('burnLoot', [[summoner.address], [burning]])
+      
+      await expect(
+        submitAndProcessProposal(baal, burnLootAction)
+      ).to.emit(baal, 'ProcessProposal').withArgs(1)
+
+      expect((await (baal.members(summoner.address))).loot).to.equal(loot - burning)
 
     })
   })

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -82,12 +82,12 @@ describe('Baal contract', function () {
   const yes = true
   const no = false
 
-  async function submitAndProcessProposal(baalAsAddress: Baal, action: any) {
+  async function submitAndProcessProposal(baalAsAddress: Baal, action: any, proposalIndex = 1) {
     const encodedAction = encodeMultiAction(multisend, [action], [baalAsAddress.address], [BigNumber.from(0)], [0])
     await baalAsAddress.submitProposal(proposal.votingPeriod, encodedAction, proposal.expiration, ethers.utils.id(proposal.details))
     await baalAsAddress.submitVote(1, true)
     await moveForwardPeriods(2)
-    return await baalAsAddress.processProposal(1, proposal.revertOnFailure)
+    return await baalAsAddress.processProposal(proposalIndex, proposal.revertOnFailure)
   }
 
   async function enableShaman(shamanToEnable: SignerWithAddress) {

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -347,7 +347,7 @@ describe('Baal contract', function () {
       // mint shares for the delegator
       await expect(
         baalAsShaman.mintShares([applicant.address], [minting])
-      ).to.emit(baal, 'DelegateVotesChanged').withArgs(summoner.address, shares + 2 * minting)
+      ).to.emit(baal, 'DelegateVotesChanged').withArgs(summoner.address, shares + minting, shares + 2 * minting)
 
       expect(await baal.balanceOf(applicant.address)).to.equal(2 * minting)
       expect(await baal.delegates(applicant.address)).to.equal(summoner.address)

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -464,6 +464,22 @@ describe('Baal contract', function () {
     })
   })
 
+  describe('test all actions callable via proposal', function () {
+    it('happy case - mint shares', async function () {
+      const minting = 100
+
+      expect(await baal.balanceOf(applicant.address)).to.equal(0)
+
+      const mintSharesAction = await baal.interface.encodeFunctionData('mintShares', [[applicant.address], [minting]])
+      
+      await expect(
+        submitAndProcessProposal(baal, mintSharesAction)
+      ).to.emit(baal, 'ProcessProposal')
+
+      expect(await baal.balanceOf(applicant.address)).to.equal(minting)
+    })
+  })
+
   describe('ragequit', function () {
     beforeEach(async function () {
       await baal.submitProposal(proposal.votingPeriod, proposal.data, proposal.expiration, ethers.utils.id(proposal.details))

--- a/test/Baal.test.ts
+++ b/test/Baal.test.ts
@@ -544,8 +544,6 @@ describe('Baal contract', function () {
       await submitAndProcessProposal(baal, removeWethAction)
 
       expect(await baal.getGuildTokens()).to.eql([])
-
-
     })
   })
 


### PR DESCRIPTION
- Add more to the "require" message in processProposal
- Extend utility methods in test file for submitting multiple proposals
- Add test cases for executing via proposal: mint/burn loot/shares, set/unset tokens & shamans

share/loot transference coverage forthcoming